### PR TITLE
Add validation to certs dumper

### DIFF
--- a/templates/bin/copy-certificates.sh
+++ b/templates/bin/copy-certificates.sh
@@ -13,7 +13,7 @@ in=$1
 staging=$2
 out=$3
 
-echo 'Copying traefik-certs-dumper certificates ('$in') to '$out' via '$staging
+echo "Copying traefik-certs-dumper certificates ($in) to $out via $staging"
 
 cp -ar "$in/." "$staging/."
 

--- a/templates/bin/copy-certificates.sh
+++ b/templates/bin/copy-certificates.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 if [ $# -ne 3 ]; then
   echo "Usage: $0 <in_dir> <staging_dir> <out_dir>" >&2
   exit 1

--- a/templates/bin/copy-certificates.sh
+++ b/templates/bin/copy-certificates.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <in_dir> <staging_dir> <out_dir>" >&2
+  exit 1
+fi
 
 in=$1
 staging=$2
@@ -10,10 +11,10 @@ out=$3
 
 echo 'Copying traefik-certs-dumper certificates ('$in') to '$out' via '$staging
 
-cp -ar $in/. $staging/.
+cp -ar "$in/." "$staging/."
 
-chown -R {{ traefik_certs_dumper_dumped_certificates_dir_owner }}:{{ traefik_certs_dumper_dumped_certificates_dir_group }} $staging
+chown -R {{ traefik_certs_dumper_dumped_certificates_dir_owner }}:{{ traefik_certs_dumper_dumped_certificates_dir_group }} "$staging"
 
-rm -rf $out/*
+rm -rf "$out"/*
 
-mv $staging/* $out/.
+mv "$staging"/* "$out"/.

--- a/templates/bin/copy-certificates.sh
+++ b/templates/bin/copy-certificates.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-if [ $# -ne 3 ]; then
+if [ $# -ne 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
   echo "Usage: $0 <in_dir> <staging_dir> <out_dir>" >&2
   exit 1
 fi


### PR DESCRIPTION
When you run ./copy-certificates.sh without arguments, all three variables ($in, $staging, $out) are empty. This means $out expands to an empty string, so the command becomes: `rm -rf /*`. This validation was tested on Debian 12 and 13.